### PR TITLE
Use UUIDs + migrate existing IDs

### DIFF
--- a/client/helpers/main.lua
+++ b/client/helpers/main.lua
@@ -46,6 +46,25 @@ BccUtils.RPC:Register("feather-banks:NotifyClient", function(data)
     Notify(data.message, data.type, data.duration)
 end)
 
+function NormalizeId(value)
+    if value == nil then return nil end
+    if type(value) == 'number' then
+        if value ~= value then return nil end
+        return string.format('%.0f', value)
+    end
+    local str = tostring(value)
+    str = str:match('^%s*(.-)%s*$') or str
+    if str == '' then return nil end
+    return str
+end
+
+function IdsEqual(left, right)
+    local a = NormalizeId(left)
+    local b = NormalizeId(right)
+    if not a or not b then return false end
+    return a == b
+end
+
 if Config.devMode then
     function devPrint(...)
         local args = { ... }

--- a/client/menus/AccessPage.lua
+++ b/client/menus/AccessPage.lua
@@ -150,8 +150,10 @@ function OpenRemoveAccessPage(account, ParentPage)
         style = {}
     })
 
+    local accountId = NormalizeId(account.id)
+
     local ok, response = BccUtils.RPC:CallAsync("Feather:Banks:GetAccountAccessList", {
-        account = account.id
+        account = accountId
     })
 
     if not ok or not response or type(response) ~= "table" then return end
@@ -192,7 +194,7 @@ function OpenRemoveAccessPage(account, ParentPage)
                     style = {}
                 }, function()
                     local ok = BccUtils.RPC:CallAsync("Feather:Banks:RemoveAccountAccess", {
-                        account   = account.id,
+                        account   = accountId,
                         character = access.character_id
                     })
 

--- a/client/menus/AdminMenu.lua
+++ b/client/menus/AdminMenu.lua
@@ -220,7 +220,7 @@ function OpenAdminHoursMenu(Parent, bank)
 
     -- Prefetch hours (no fetch button)
     do
-        local bankId = tonumber(bankIdValue) or (bank and tonumber(bank.id))
+        local bankId = NormalizeId(bankIdValue) or (bank and NormalizeId(bank.id))
         if bankId then
             local ok, data = BccUtils.RPC:CallAsync('Feather:Banks:Admin:GetHours', { bank = bankId })
             if ok and data then
@@ -240,7 +240,7 @@ function OpenAdminHoursMenu(Parent, bank)
         start = hoursActive,
         slot = 'content',
     }, function(data)
-        local bankId = tonumber(bankIdValue) or (bank and tonumber(bank.id))
+        local bankId = NormalizeId(bankIdValue) or (bank and NormalizeId(bank.id))
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ToggleHours', { bank = bankId, active = data.value and true or false })
         Notify(ok and (data.value and (_U('admin_hours_enabled') or 'Hours enabled.') or (_U('admin_hours_disabled') or 'Hours disabled.')) or _U('admin_action_failed'), ok and 'success' or 'error', 3500)
@@ -254,7 +254,7 @@ function OpenAdminHoursMenu(Parent, bank)
         closeVal = data.value
     end)
     Page:RegisterElement('button', { label = _U('admin_set_hours_button') or 'Set Hours', style = {} }, function()
-        local bankId = tonumber(bankIdValue) or (bank and tonumber(bank.id))
+        local bankId = NormalizeId(bankIdValue) or (bank and NormalizeId(bank.id))
         local openH = tonumber(openVal)
         local closeH = tonumber(closeVal)
         if not bankId or openH == nil or closeH == nil then Notify(_U('admin_invalid_hours_input') or 'Enter valid bank/hours', 3000) return end
@@ -301,7 +301,7 @@ function OpenAdminRatesMenu(Parent, bank)
         label = _U('admin_get_bank_rate_button'),
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok, rate = BccUtils.RPC:CallAsync('Feather:Banks:Admin:GetBankRate', { bank = bankId })
         local msg = ok and (_U('admin_current_rate') .. ' ' .. (rate and toFixed(rate, 2) .. '%' or _U('admin_rate_not_set'))) or _U('admin_action_failed')
@@ -318,7 +318,7 @@ function OpenAdminRatesMenu(Parent, bank)
         label = _U('admin_set_bank_rate_button'),
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         local rate = tonumber(newRateValue)
         if not bankId or not rate then Notify(_U('admin_invalid_input'), 3000) return end
         local ok = BccUtils.RPC:CallAsync('Feather:Banks:Admin:SetBankRate', { bank = bankId, rate = rate })
@@ -489,7 +489,7 @@ function OpenAdminAccountsMenu(Parent, bank)
         label = _U('admin_fetch_button'),
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok, rows = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ListAccounts', { bank = bankId })
         if not ok then Notify(_U('admin_action_failed'), 3000) return end
@@ -551,7 +551,7 @@ function OpenAdminLoansMenu(Parent, bank)
         label = _U('admin_fetch_button'),
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok, rows = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ListLoans', { bank = bankId })
         if not ok then Notify(_U('admin_action_failed'), 3000) return end
@@ -569,7 +569,7 @@ function OpenAdminLoansMenu(Parent, bank)
         label = _U('admin_fetch_pending_button') or 'Fetch Pending Loans',
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok, rows = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ListPendingLoans', { bank = bankId })
         if not ok then Notify(_U('admin_action_failed'), 3000) return end
@@ -603,7 +603,7 @@ function OpenAdminLoansMenu(Parent, bank)
                     label = _U('admin_approve_button') or 'Approve',
                     style = {}
                 }, function()
-                    local okA = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ApproveLoan', { loan = r.id })
+                    local okA = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ApproveLoan', { loan = NormalizeId(r.id) })
                     if okA then Notify(_U('admin_approved_notify') or 'Approved', 2500) end
                     OpenAdminLoansMenu(Parent, bank)
                 end)
@@ -611,7 +611,7 @@ function OpenAdminLoansMenu(Parent, bank)
                     label = _U('admin_reject_button') or 'Reject',
                     style = {}
                 }, function()
-                    local okR = BccUtils.RPC:CallAsync('Feather:Banks:Admin:RejectLoan', { loan = r.id })
+                    local okR = BccUtils.RPC:CallAsync('Feather:Banks:Admin:RejectLoan', { loan = NormalizeId(r.id) })
                     if okR then Notify(_U('admin_rejected_notify') or 'Rejected', 2500) end
                     OpenAdminLoansMenu(Parent, bank)
                 end)
@@ -685,7 +685,7 @@ function OpenAdminSDBsMenu(Parent, bank)
         label = _U('admin_fetch_button'),
         style = {}
     }, function()
-        local bankId = tonumber(bankIdValue)
+        local bankId = NormalizeId(bankIdValue)
         if not bankId then Notify(_U('admin_invalid_bank_id'), 3000) return end
         local ok, rows = BccUtils.RPC:CallAsync('Feather:Banks:Admin:ListSDBs', { bank = bankId })
         if not ok then Notify(_U('admin_action_failed'), 3000) return end

--- a/client/menus/SafetyDepositBox.lua
+++ b/client/menus/SafetyDepositBox.lua
@@ -241,15 +241,15 @@ function OpenSDBInventory(sdb, ParentPage)
     SetNuiFocus(false, false)
     devPrint('[SDB] Bank menu closed, focus released; waiting...')
     Wait(250)
-    local sdbIdNum = tonumber(sdb and sdb.id)
-    devPrint('[SDB] Converting sdb.id to number ->', tostring(sdbIdNum))
-    local ok = BccUtils.RPC:CallAsync('Feather:Banks:OpenSDB', { sdb_id = sdbIdNum })
+    local sdbId = NormalizeId(sdb and sdb.id)
+    devPrint('[SDB] Normalized sdb.id ->', tostring(sdbId))
+    local ok = BccUtils.RPC:CallAsync('Feather:Banks:OpenSDB', { sdb_id = sdbId })
     devPrint('[SDB] RPC Feather:Banks:OpenSDB returned:', tostring(ok))
     if not ok then
-        devPrint('[SDB] OpenSDB RPC failed for id=', tostring(sdbIdNum))
+        devPrint('[SDB] OpenSDB RPC failed for id=', tostring(sdbId))
         Notify(_U('error_unable_open_sdb') or 'Unable to open Safety Deposit Box.', 'error', 3500)
     else
-        devPrint('[SDB] Opened inventory for id=', tostring(sdbIdNum))
+        devPrint('[SDB] Opened inventory for id=', tostring(sdbId))
     end
 end
 
@@ -332,7 +332,7 @@ function OpenSDBGiveAccessPage(sdb, ParentPage, SDBListPage)
             return
         end
         local ok, res = BccUtils.RPC:CallAsync('Feather:Banks:AddSDBAccess', {
-            sdb_id   = sdb.id,
+            sdb_id   = NormalizeId(sdb.id),
             user_src = charId,
             level    = level
         })
@@ -366,7 +366,7 @@ function OpenSDBRemoveAccessPage(sdb, ParentPage, SDBListPage)
         slot  = 'header',
         style = {}
     })
-    local ok, result = BccUtils.RPC:CallAsync('Feather:Banks:GetSDBAccessList', { sdb_id = sdb.id })
+    local ok, result = BccUtils.RPC:CallAsync('Feather:Banks:GetSDBAccessList', { sdb_id = NormalizeId(sdb.id) })
     local accessList = (ok and result and result.access) or {}
     if #accessList == 0 then
         SDBRemoveAccessPage:RegisterElement('textdisplay', {
@@ -397,7 +397,7 @@ function OpenSDBRemoveAccessPage(sdb, ParentPage, SDBListPage)
                     style = {}
                 }, function()
                     local ok = BccUtils.RPC:CallAsync('Feather:Banks:RemoveSDBAccess', {
-                        sdb_id    = sdb.id,
+                        sdb_id    = NormalizeId(sdb.id),
                         character = access.character_id
                     })
                     OpenSDBRemoveAccessPage(sdb, ParentPage, SDBListPage)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 
 game 'rdr3'
 lua54 'yes'
-version '1.1.1'
+version '1.2.0'
 author 'BCC Scripts'
 
 client_scripts {

--- a/server/controllers/accounts.lua
+++ b/server/controllers/accounts.lua
@@ -57,9 +57,10 @@ function CreateAccount(name, owner, bank)
 
     local acctNum = nextUniqueAccountNumber()
 
+    local accountId = BccUtils.UUID()
     local result = MySQL.query.await(
-        'INSERT INTO `bcc_accounts` (account_number, name, bank_id, owner_id) VALUES (?, ?, ?, ?) RETURNING *;',
-        { acctNum, name, bank, owner }
+        'INSERT INTO `bcc_accounts` (id, account_number, name, bank_id, owner_id) VALUES (?, ?, ?, ?, ?) RETURNING *;',
+        { accountId, acctNum, name, bank, owner }
     )
     local account = result and result[1]
 
@@ -107,9 +108,10 @@ function CreateAccountReturn(name, owner, bank)
 
     local acctNum = nextUniqueAccountNumber()
 
+    local accountId = BccUtils.UUID()
     local result = MySQL.query.await(
-        'INSERT INTO `bcc_accounts` (account_number, name, bank_id, owner_id) VALUES (?, ?, ?, ?) RETURNING *;',
-        { acctNum, name, bank, owner }
+        'INSERT INTO `bcc_accounts` (id, account_number, name, bank_id, owner_id) VALUES (?, ?, ?, ?, ?) RETURNING *;',
+        { accountId, acctNum, name, bank, owner }
     )
     local account = result and result[1]
 

--- a/server/controllers/banks.lua
+++ b/server/controllers/banks.lua
@@ -6,16 +6,20 @@ function GetBanks()
 end
 
 function IsBankerBusy(bank, src)
-	return Bankers[bank] ~= nil and Bankers[bank] ~= src
+    local key = NormalizeId(bank)
+    if not key then return false end
+    return Bankers[key] ~= nil and Bankers[key] ~= src
 end
 
 function SetBankerBusy(bank, src)
-	Bankers[bank] = src
+    local key = NormalizeId(bank)
+    if not key then return end
+    Bankers[key] = src
 end
 
 function ClearBankerBusy(src)
-	for k, v in pairs(Bankers) do
-		if v == src then
+    for k, v in pairs(Bankers) do
+        if v == src then
 			Bankers[k] = nil
 			return
 		end

--- a/server/controllers/safetydepositboxes.lua
+++ b/server/controllers/safetydepositboxes.lua
@@ -96,16 +96,17 @@ function CreateSDB(name, ownerId, bankId, sizeKey)
     end
 
     -- insert -> id
-    local newId = MySQL.insert.await(
-        'INSERT INTO `bcc_safety_deposit_boxes` (`name`, `bank_id`, `owner_id`, `size`) VALUES (?,?,?,?)',
-        { name, bankId, ownerId, resolvedKey }
+    local boxId = BccUtils.UUID()
+    local inserted = MySQL.query.await(
+        'INSERT INTO `bcc_safety_deposit_boxes` (`id`, `name`, `bank_id`, `owner_id`, `size`) VALUES (?,?,?,?,?)',
+        { boxId, name, bankId, ownerId, resolvedKey }
     )
-    if not newId or newId <= 0 then
+    if not inserted then
         return false, "Could not create SDB."
     end
 
     -- load box row
-    local box = MySQL.single.await('SELECT * FROM `bcc_safety_deposit_boxes` WHERE `id`=? LIMIT 1;', { newId })
+    local box = MySQL.single.await('SELECT * FROM `bcc_safety_deposit_boxes` WHERE `id`=? LIMIT 1;', { boxId })
     if not box then
         return false, "SDB row not found after insert."
     end

--- a/server/controllers/transactions.lua
+++ b/server/controllers/transactions.lua
@@ -13,11 +13,12 @@ function GetAccountTransactions(account)
 end
 
 function AddAccountTransaction(account, character, amount, txType, description)
+    local txId = BccUtils.UUID()
     MySQL.query.await(
         'INSERT INTO `bcc_transactions` ' ..
-        '(`account_id`, `character_id`, `amount`, `type`, `description`) ' ..
-        'VALUES (?, ?, ?, ?, ?);',
-        { account, character, amount, txType, description }
+        '(`id`, `account_id`, `character_id`, `amount`, `type`, `description`) ' ..
+        'VALUES (?, ?, ?, ?, ?, ?);',
+        { txId, account, character, amount, txType, description }
     )
     return true
 end
@@ -34,11 +35,12 @@ function GetLoanTransactions(loan)
 end
 
 function AddLoanTransaction(loan, character, amount, txType, description)
+    local txId = BccUtils.UUID()
     MySQL.query.await(
         'INSERT INTO `bcc_transactions` ' ..
-        '(`loan_id`, `character_id`, `amount`, `type`, `description`) ' ..
-        'VALUES (?, ?, ?, ?, ?);',
-        { loan, character, amount, txType, description }
+        '(`id`, `loan_id`, `character_id`, `amount`, `type`, `description`) ' ..
+        'VALUES (?, ?, ?, ?, ?, ?);',
+        { txId, loan, character, amount, txType, description }
     )
     return true
 end

--- a/server/helpers/functions.lua
+++ b/server/helpers/functions.lua
@@ -6,6 +6,25 @@ function NotifyClient(src, message, type, duration)
     }, src)
 end
 
+function NormalizeId(value)
+    if value == nil then return nil end
+    if type(value) == 'number' then
+        if value ~= value then return nil end
+        return string.format('%.0f', value)
+    end
+    local str = tostring(value)
+    str = str:match('^%s*(.-)%s*$') or str
+    if str == '' then return nil end
+    return str
+end
+
+function IdsEqual(left, right)
+    local a = NormalizeId(left)
+    local b = NormalizeId(right)
+    if not a or not b then return false end
+    return a == b
+end
+
 if Config.devMode then
     function devPrint(...)
         local args = { ... }

--- a/server/services/accounts.lua
+++ b/server/services/accounts.lua
@@ -16,7 +16,7 @@ BccUtils.RPC:Register('Feather:Banks:GetAccounts', function(params, cb, src)
         return
     end
     local characterId = char.charIdentifier
-    local bankId = tonumber(params and params.bank)
+    local bankId = NormalizeId(params and params.bank)
 
     devPrint("Parsed bankId:", bankId, "characterId:", characterId)
 
@@ -57,7 +57,7 @@ end)
 
 -- Public: list all accounts for a bank (minimal fields)
 BccUtils.RPC:Register('Feather:Banks:ListAccountsByBank', function(params, cb, src)
-    local bankId = tonumber(params and params.bank)
+    local bankId = NormalizeId(params and params.bank)
     devPrint('ListAccountsByBank RPC called. src=', src, 'bank=', bankId)
     if not bankId then
         cb(false)
@@ -97,7 +97,7 @@ BccUtils.RPC:Register('Feather:Banks:CreateAccount', function(params, cb, src)
     end
     local characterId = char.charIdentifier
     local name = params and params.name
-    local bank = tonumber(params and params.bank)
+    local bank = NormalizeId(params and params.bank)
 
     devPrint("Fetched character:", char)
     devPrint("CreateAccount inputs -> name:", name, "bank:", bank, "characterId:", characterId)
@@ -152,8 +152,8 @@ BccUtils.RPC:Register('Feather:Banks:CloseAccount', function(params, cb, src)
         return
     end
     local characterId = char.charIdentifier
-    local bank = tonumber(params and params.bank)
-    local account = tonumber(params and params.account)
+    local bank = NormalizeId(params and params.bank)
+    local account = NormalizeId(params and params.account)
 
     devPrint("CloseAccount inputs -> bank:", bank, "account:", account, "characterId:", characterId)
 
@@ -202,7 +202,7 @@ BccUtils.RPC:Register('Feather:Banks:GetAccount', function(params, cb, src)
         return
     end
     local characterId = char.charIdentifier
-    local accId = tonumber(params and params.account)
+    local accId = NormalizeId(params and params.account)
     local lockAccount = params and params.lockAccount
 
     devPrint("GetAccount inputs -> accId:", accId, "characterId:", characterId, "lockAccount:", lockAccount)
@@ -262,7 +262,7 @@ end)
 BccUtils.RPC:Register('Feather:Banks:UnlockAccount', function(params, cb, src)
     devPrint("UnlockAccount RPC called. src=", src, "params=", params)
 
-    local accId = tonumber(params and params.account)
+    local accId = NormalizeId(params and params.account)
     if not accId then
         devPrint("UnlockAccount: invalid account id.")
         NotifyClient(src, _U('error_invalid_account_id'), 'error', 4000)
@@ -284,7 +284,7 @@ end)
 BccUtils.RPC:Register('Feather:Banks:GetAccountAccessList', function(params, cb, src)
     devPrint("GetAccountAccessList RPC called. src=", src, "params=", params)
 
-    local account = tonumber(params.account)
+    local account = NormalizeId(params.account)
     devPrint("Parsed account ID:", account)
 
     if not account then
@@ -334,7 +334,7 @@ BccUtils.RPC:Register('Feather:Banks:GiveAccountAccess', function(params, cb, sr
         return
     end
     local requesterId = user.getUsedCharacter.charIdentifier
-    local account = tonumber(params and params.account)
+    local account = NormalizeId(params and params.account)
     -- Expect VORP character identifier (charidentifier) from client
     local otherCharacter = tonumber(params and params.character)
     if not otherCharacter then
@@ -406,7 +406,7 @@ BccUtils.RPC:Register('Feather:Banks:RemoveAccountAccess', function(params, cb, 
     end
     local requesterId = user.getUsedCharacter.charIdentifier
 
-    local account = tonumber(params.account)
+    local account = NormalizeId(params.account)
     local target = tonumber(params.character)
 
     devPrint("Parsed inputs → account:", account, "target:", target, "requesterId:", requesterId)
@@ -457,7 +457,7 @@ BccUtils.RPC:Register('Feather:Banks:DepositCash', function(params, cb, src)
     end
     local char = user.getUsedCharacter
 
-    local account        = tonumber(params and params.account)
+    local account        = NormalizeId(params and params.account)
     local amount         = tonumber(params and params.amount)
     local description    = (params and params.description) or "No description provided"
     local currentDollars = tonumber(char.money)
@@ -513,7 +513,7 @@ BccUtils.RPC:Register('Feather:Banks:DepositGold', function(params, cb, src)
     end
     local char = user.getUsedCharacter
 
-    local account     = tonumber(params and params.account)
+    local account     = NormalizeId(params and params.account)
     local amount      = tonumber(params and params.amount)
     local description = (params and params.description) or "No description provided"
     local currentGold = tonumber(char.gold)
@@ -568,7 +568,7 @@ BccUtils.RPC:Register('Feather:Banks:WithdrawCash', function(params, cb, src)
     end
     local char = user.getUsedCharacter
 
-    local account     = tonumber(params and params.account)
+    local account     = NormalizeId(params and params.account)
     local amount      = tonumber(params and params.amount)
     local description = (params and params.description) or "No description provided"
 
@@ -624,7 +624,7 @@ BccUtils.RPC:Register('Feather:Banks:WithdrawGold', function(params, cb, src)
     end
     local char = user.getUsedCharacter
 
-    local account     = tonumber(params and params.account)
+    local account     = NormalizeId(params and params.account)
     local amount      = tonumber(params and params.amount)
     local description = (params and params.description) or "No description provided"
 
@@ -687,9 +687,9 @@ BccUtils.RPC:Register('Feather:Banks:TransferCash', function(params, cb, src)
     end
     local char = user.getUsedCharacter
 
-    local fromAccountId = tonumber(params and params.fromAccount)
+    local fromAccountId = NormalizeId(params and params.fromAccount)
     local toAccountNumber = params and params.toAccountNumber
-    local toAccountId = tonumber(params and params.toAccountId)
+    local toAccountId = NormalizeId(params and params.toAccountId)
     local amount = tonumber(params and params.amount)
     local description = (params and params.description) or "Bank transfer"
 
@@ -744,7 +744,7 @@ BccUtils.RPC:Register('Feather:Banks:TransferCash', function(params, cb, src)
 
     devPrint("Loaded toAcc -> id:", toAcc.id, "bank:", toAcc.bank_id, "cash:", toAcc.cash)
 
-    if tonumber(toAcc.id) == tonumber(fromAcc.id) then
+    if IdsEqual(toAcc.id, fromAcc.id) then
         NotifyClient(src, _U('error_same_account_transfer'), 'error', 4000)
         cb(false)
         return
@@ -752,7 +752,7 @@ BccUtils.RPC:Register('Feather:Banks:TransferCash', function(params, cb, src)
 
     -- Calculate fee if cross-bank
     local feePercent = 0.0
-    if tonumber(fromAcc.bank_id) ~= tonumber(toAcc.bank_id) then
+    if not IdsEqual(fromAcc.bank_id, toAcc.bank_id) then
         feePercent = tonumber(Config.Transfer.CrossBankFeePercent or 0.0) or 0.0
     end
 

--- a/server/services/banks.lua
+++ b/server/services/banks.lua
@@ -40,7 +40,8 @@ BccUtils.RPC:Register('Feather:Banks:CreateBank', function(params, res, src)
         return
     end
 
-    local ok = MySQL.query.await('INSERT INTO `bcc_banks` (name, x, y, z, h) VALUES (?, ?, ?, ?, ?);', { name, x, y, z, heading })
+    local bankId = BccUtils.UUID()
+    local ok = MySQL.query.await('INSERT INTO `bcc_banks` (id, name, x, y, z, h) VALUES (?, ?, ?, ?, ?, ?);', { bankId, name, x, y, z, heading })
     if ok == nil then
         NotifyClient(src, _U('admin_action_failed') or 'Action failed.', 'error', 3500)
         res(false)

--- a/server/services/database.lua
+++ b/server/services/database.lua
@@ -2,7 +2,7 @@ CreateThread(function()
     -- bcc_banks
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_banks` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id` VARCHAR(36) NOT NULL,
             `name` VARCHAR(255) NOT NULL UNIQUE,
             `x` DECIMAL(15,2) NOT NULL,
             `y` DECIMAL(15,2) NOT NULL,
@@ -17,7 +17,7 @@ CreateThread(function()
     ]])
 
     -- Ensure column exists for existing installations (add if missing)
-    local col = MySQL.query.await([[ 
+    local col = MySQL.query.await([[
         SELECT COUNT(*) AS cnt
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_SCHEMA = DATABASE()
@@ -33,10 +33,10 @@ CreateThread(function()
     -- bcc_accounts (no FK to characters)
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_accounts` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id` VARCHAR(36) NOT NULL,
             `account_number` CHAR(36) NOT NULL,
             `name` VARCHAR(255) NOT NULL,
-            `bank_id` BIGINT UNSIGNED NOT NULL,
+            `bank_id` VARCHAR(36) NOT NULL,
             `owner_id` BIGINT UNSIGNED NOT NULL,
             `cash` DOUBLE(15,2) DEFAULT 0.0,
             `gold` DOUBLE(15,2) DEFAULT 0.0,
@@ -54,7 +54,7 @@ CreateThread(function()
     -- bcc_accounts_access
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_accounts_access` (
-            `account_id` BIGINT UNSIGNED NOT NULL,
+            `account_id` VARCHAR(36) NOT NULL,
             `character_id` BIGINT UNSIGNED NOT NULL,
             `level` INT UNSIGNED DEFAULT 2,
             PRIMARY KEY (`account_id`, `character_id`),
@@ -69,9 +69,9 @@ CreateThread(function()
     -- bcc_loans (no FK to characters)
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_loans` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            `account_id` BIGINT UNSIGNED NULL,
-            `bank_id` BIGINT UNSIGNED NULL,
+            `id` VARCHAR(36) NOT NULL,
+            `account_id` VARCHAR(36) NULL,
+            `bank_id` VARCHAR(36) NULL,
             `character_id` BIGINT UNSIGNED NOT NULL,
             `amount` DOUBLE(15,2) NOT NULL,
             `interest` DOUBLE(15,2) NOT NULL,
@@ -79,7 +79,7 @@ CreateThread(function()
             `status` VARCHAR(20) NOT NULL DEFAULT 'pending',
             `approved_by` BIGINT UNSIGNED NULL,
             `approved_at` DATETIME NULL,
-            `disbursed_account_id` BIGINT UNSIGNED NULL,
+            `disbursed_account_id` VARCHAR(36) NULL,
             `disbursed_at` DATETIME NULL,
             `last_game_day` INT NULL,
             `game_days_elapsed` INT UNSIGNED NOT NULL DEFAULT 0,
@@ -102,8 +102,8 @@ CreateThread(function()
     -- bcc_loans_payments
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_loans_payments` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            `loan_id` BIGINT UNSIGNED NOT NULL,
+            `id` VARCHAR(36) NOT NULL,
+            `loan_id` VARCHAR(36) NOT NULL,
             `amount` DOUBLE(15,2) NOT NULL,
             `date_due` DATETIME NOT NULL,
             `is_paid` BOOLEAN NOT NULL DEFAULT FALSE,
@@ -121,7 +121,7 @@ CreateThread(function()
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_loan_interest_rates` (
             `character_id` BIGINT UNSIGNED NOT NULL,
-            `bank_id` BIGINT UNSIGNED NOT NULL,
+            `bank_id` VARCHAR(36) NOT NULL,
             `interest` DOUBLE(15,2) NOT NULL,
             PRIMARY KEY (`character_id`, `bank_id`),
             KEY `idx_lir_bank` (`bank_id`),
@@ -132,7 +132,7 @@ CreateThread(function()
     -- bcc_bank_interest_rates (per-bank base rate used by admin UI)
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_bank_interest_rates` (
-            `bank_id` BIGINT UNSIGNED NOT NULL,
+            `bank_id` VARCHAR(36) NOT NULL,
             `interest` DOUBLE(15,2) NOT NULL,
             PRIMARY KEY (`bank_id`),
             KEY `idx_bir_bank` (`bank_id`)
@@ -142,9 +142,9 @@ CreateThread(function()
     -- bcc_transactions (no FK to characters)
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_transactions` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            `account_id` BIGINT UNSIGNED,
-            `loan_id` BIGINT UNSIGNED,
+            `id` VARCHAR(36) NOT NULL,
+            `account_id` VARCHAR(36),
+            `loan_id` VARCHAR(36),
             `character_id` BIGINT UNSIGNED NOT NULL,
             `amount` DOUBLE(15,2) NOT NULL,
             `type` VARCHAR(255) NOT NULL,
@@ -162,9 +162,9 @@ CreateThread(function()
     -- bcc_safety_deposit_boxes (no FK to characters)
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_safety_deposit_boxes` (
-            `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id` VARCHAR(36) NOT NULL,
             `name` VARCHAR(255) NOT NULL,
-            `bank_id` BIGINT UNSIGNED NOT NULL,
+            `bank_id` VARCHAR(36) NOT NULL,
             `owner_id` BIGINT UNSIGNED NOT NULL,
             `size` VARCHAR(255) NOT NULL,
             `inventory_id` CHAR(36) NULL,
@@ -180,7 +180,7 @@ CreateThread(function()
     -- bcc_safety_deposit_boxes_access
     MySQL.query.await([[
         CREATE TABLE IF NOT EXISTS `bcc_safety_deposit_boxes_access` (
-            `safety_deposit_box_id` BIGINT UNSIGNED NOT NULL,
+            `safety_deposit_box_id` VARCHAR(36) NOT NULL,
             `character_id` BIGINT UNSIGNED NOT NULL,
             `level` INT UNSIGNED DEFAULT 2,
             PRIMARY KEY (`safety_deposit_box_id`, `character_id`),
@@ -195,12 +195,12 @@ CreateThread(function()
 
     -- Optional seed
     MySQL.query.await([[
-        INSERT IGNORE INTO `bcc_banks` (`name`, `x`, `y`, `z`, `h`, `blip`, `hours_active`, `open_hour`, `close_hour`)
+        INSERT IGNORE INTO `bcc_banks` (`id`, `name`, `x`, `y`, `z`, `h`, `blip`, `hours_active`, `open_hour`, `close_hour`)
         VALUES 
-        ('Valentine', -307.82, 773.96, 118.70, 2.88, -2128054417, 0, 7, 21),
-        ('BlackWater', -810.51, -1275.37, 43.64, 189.16, -2128054417, 0, 7, 21),
-        ('Rhodes', 1291.25, -1303.30, 77.04, 322.24, -2128054417, 0, 7, 21),
-        ('SaintDenis', 2644.15, -1296.16, 52.25, 111.40, -2128054417, 0, 7, 21);
+        (UUID(), 'Valentine', -307.82, 773.96, 118.70, 2.88, -2128054417, 0, 7, 21),
+        (UUID(), 'BlackWater', -810.51, -1275.37, 43.64, 189.16, -2128054417, 0, 7, 21),
+        (UUID(), 'Rhodes', 1291.25, -1303.30, 77.04, 322.24, -2128054417, 0, 7, 21),
+        (UUID(), 'SaintDenis', 2644.15, -1296.16, 52.25, 111.40, -2128054417, 0, 7, 21);
     ]])
 
     devPrint("Database tables for *bcc-banks* created successfully.")

--- a/server/services/loans.lua
+++ b/server/services/loans.lua
@@ -78,8 +78,8 @@ end
 BccUtils.RPC:Register('Feather:Banks:GetLoans', function(params, cb, src)
     devPrint('GetLoans RPC called. src=', src, 'params=', params)
 
-    local account_id = tonumber(params and params.account)
-    local bank_id    = tonumber(params and params.bank)
+    local account_id = NormalizeId(params and params.account)
+    local bank_id    = NormalizeId(params and params.bank)
 
     local user = VORPcore.getUser(src)
     if not user then
@@ -119,7 +119,7 @@ BccUtils.RPC:Register('Feather:Banks:GetLoans', function(params, cb, src)
 end)
 
 BccUtils.RPC:Register('Feather:Banks:GetLoan', function(params, cb, src)
-    local loan_id = tonumber(params and params.loan)
+    local loan_id = NormalizeId(params and params.loan)
     if not loan_id then
         NotifyClient(src, _U('error_invalid_loan_id'), 'error', 4000)
         cb(false)
@@ -149,8 +149,8 @@ BccUtils.RPC:Register('Feather:Banks:ClaimLoanDisbursement', function(params, cb
     end
     local characterId = char.charIdentifier
 
-    local loan_id    = tonumber(params and params.loan)
-    local account_id = tonumber(params and params.account)
+    local loan_id    = NormalizeId(params and params.loan)
+    local account_id = NormalizeId(params and params.account)
     if not loan_id or not account_id then
         NotifyClient(src, _U('error_invalid_input'), 'error', 4000)
         cb(false)
@@ -189,8 +189,8 @@ BccUtils.RPC:Register('Feather:Banks:CreateLoan', function(params, cb, src)
         return
     end
 
-    local account_id = tonumber(params and params.account)
-    local bankId     = tonumber(params and params.bank)
+    local account_id = NormalizeId(params and params.account)
+    local bankId     = NormalizeId(params and params.bank)
     local amount     = tonumber(params and params.amount)
     local duration   = tonumber(params and params.duration) or 0
 
@@ -247,8 +247,8 @@ BccUtils.RPC:Register('Feather:Banks:GetLoanRate', function(params, cb, src)
         cb(false)
         return
     end
-    local account_id = tonumber(params and params.account)
-    local bankId = account_id and GetBankIdForAccount(account_id) or tonumber(params and params.bank)
+    local account_id = NormalizeId(params and params.account)
+    local bankId = account_id and GetBankIdForAccount(account_id) or NormalizeId(params and params.bank)
     local rate = GetCharacterLoanInterest(characterId, bankId)
     cb(true, rate)
 end)
@@ -325,7 +325,7 @@ BccUtils.RPC:Register('Feather:Banks:RepayLoan', function(params, cb, src)
         return
     end
 
-    local loan_id   = tonumber(params and params.loan)
+    local loan_id   = NormalizeId(params and params.loan)
     local amount    = tonumber(params and params.amount)
 
     if not loan_id or not amount or amount <= 0 then

--- a/server/services/migration.lua
+++ b/server/services/migration.lua
@@ -1,0 +1,257 @@
+local function fetchColumnType(tableName, columnName)
+    local row = MySQL.single.await([[SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ? LIMIT 1;]], { tableName, columnName })
+    return row and (row.DATA_TYPE or row.data_type) or nil
+end
+
+local function countNumericIds(tableName, columnName)
+    local row = MySQL.single.await(('SELECT COUNT(*) AS cnt FROM `%s` WHERE `%s` REGEXP "^[0-9]+$";'):format(tableName, columnName))
+    return row and tonumber(row.cnt or row.CNT or row['COUNT(*)'] or 0) or 0
+end
+
+local function isLegacyNumericId(value)
+    if value == nil then return false end
+    if type(value) == 'number' then return true end
+    local str = tostring(value)
+    if str == '' then return false end
+    return str:match('^%d+$') ~= nil
+end
+
+local function buildMappingTable(tableName, columnName, mappingTable)
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`;'):format(mappingTable))
+    MySQL.query.await(('CREATE TABLE `%s` (`old_id` VARCHAR(36) PRIMARY KEY, `new_id` VARCHAR(36) NOT NULL) ENGINE=InnoDB;'):format(mappingTable))
+    MySQL.query.await(('INSERT INTO `%s` (old_id, new_id) SELECT `%s`, UUID() FROM `%s` WHERE `%s` REGEXP "^[0-9]+$";'):format(mappingTable, columnName, tableName, columnName))
+end
+
+local function dropMappingTable(mappingTable)
+    MySQL.query.await(('DROP TABLE IF EXISTS `%s`;'):format(mappingTable))
+end
+
+local function dropForeignKeysReferencing(tableName, columnName)
+    local rows = MySQL.query.await([[SELECT CONSTRAINT_NAME, TABLE_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME = ? AND REFERENCED_COLUMN_NAME = ? GROUP BY CONSTRAINT_NAME, TABLE_NAME;]], { tableName, columnName }) or {}
+    for _, row in ipairs(rows) do
+        local constraintName = row.CONSTRAINT_NAME or row.constraint_name
+        local referencingTable = row.TABLE_NAME or row.table_name
+        if constraintName and referencingTable then
+            local dropStmt = ('ALTER TABLE `%s` DROP FOREIGN KEY `%s`;'):format(referencingTable, constraintName)
+            local ok, err = pcall(function()
+                MySQL.query.await(dropStmt)
+            end)
+            if not ok then
+                devPrint('[migration] Unable to drop FK', constraintName, 'on table', referencingTable, '->', err)
+            end
+        end
+    end
+end
+
+local function ensureColumnIsVarchar(tableName, columnName)
+    local columnType = fetchColumnType(tableName, columnName)
+    if columnType and columnType:lower() == 'varchar' then
+        return
+    end
+    local stmt = ('ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(36) NOT NULL;'):format(tableName, columnName)
+    MySQL.query.await(stmt)
+end
+
+local function ensureOptionalColumnIsVarchar(tableName, columnName)
+    local columnType = fetchColumnType(tableName, columnName)
+    if columnType and columnType:lower() == 'varchar' then
+        return
+    end
+    local stmt = ('ALTER TABLE `%s` MODIFY COLUMN `%s` VARCHAR(36) NULL;'):format(tableName, columnName)
+    MySQL.query.await(stmt)
+end
+
+local function migrateBanks(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_banks` b INNER JOIN `]] .. mappingTable .. [[` m ON b.id = m.old_id SET b.id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_accounts` a INNER JOIN `]] .. mappingTable .. [[` m ON a.bank_id = m.old_id SET a.bank_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_loans` l INNER JOIN `]] .. mappingTable .. [[` m ON l.bank_id = m.old_id SET l.bank_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_safety_deposit_boxes` s INNER JOIN `]] .. mappingTable .. [[` m ON s.bank_id = m.old_id SET s.bank_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_bank_interest_rates` bir INNER JOIN `]] .. mappingTable .. [[` m ON bir.bank_id = m.old_id SET bir.bank_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_loan_interest_rates` lir INNER JOIN `]] .. mappingTable .. [[` m ON lir.bank_id = m.old_id SET lir.bank_id = m.new_id;]])
+end
+
+local function migrateAccounts(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_accounts` a INNER JOIN `]] .. mappingTable .. [[` m ON a.id = m.old_id SET a.id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_accounts_access` aa INNER JOIN `]] .. mappingTable .. [[` m ON aa.account_id = m.old_id SET aa.account_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_loans` l INNER JOIN `]] .. mappingTable .. [[` m ON l.account_id = m.old_id SET l.account_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_loans` l INNER JOIN `]] .. mappingTable .. [[` m ON l.disbursed_account_id = m.old_id SET l.disbursed_account_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_transactions` t INNER JOIN `]] .. mappingTable .. [[` m ON t.account_id = m.old_id SET t.account_id = m.new_id;]])
+end
+
+local function migrateSafetyDepositBoxes(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_safety_deposit_boxes` s INNER JOIN `]] .. mappingTable .. [[` m ON s.id = m.old_id SET s.id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_safety_deposit_boxes_access` sa INNER JOIN `]] .. mappingTable .. [[` m ON sa.safety_deposit_box_id = m.old_id SET sa.safety_deposit_box_id = m.new_id;]])
+end
+
+local function migrateLoans(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_loans` l INNER JOIN `]] .. mappingTable .. [[` m ON l.id = m.old_id SET l.id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_loans_payments` lp INNER JOIN `]] .. mappingTable .. [[` m ON lp.loan_id = m.old_id SET lp.loan_id = m.new_id;]])
+    MySQL.query.await([[UPDATE `bcc_transactions` t INNER JOIN `]] .. mappingTable .. [[` m ON t.loan_id = m.old_id SET t.loan_id = m.new_id;]])
+end
+
+local function migrateTransactions(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_transactions` t INNER JOIN `]] .. mappingTable .. [[` m ON t.id = m.old_id SET t.id = m.new_id;]])
+end
+
+local function migrateLoanPayments(mappingTable)
+    MySQL.query.await([[UPDATE `bcc_loans_payments` lp INNER JOIN `]] .. mappingTable .. [[` m ON lp.id = m.old_id SET lp.id = m.new_id;]])
+end
+
+local function cleanupOrphans()
+    -- Remove bank interest rows that refer to non-existent banks
+    MySQL.query.await([[DELETE bir FROM `bcc_bank_interest_rates` bir LEFT JOIN `bcc_banks` b ON bir.bank_id = b.id WHERE b.id IS NULL;]])
+    -- Remove loan interest rows (except global bank_id = '0') that no longer reference a bank
+    MySQL.query.await([[DELETE lir FROM `bcc_loan_interest_rates` lir LEFT JOIN `bcc_banks` b ON lir.bank_id = b.id WHERE lir.bank_id <> '0' AND b.id IS NULL;]])
+    -- Set loan bank_id to NULL if the bank no longer exists so FK with ON DELETE SET NULL can be restored
+    MySQL.query.await([[UPDATE `bcc_loans` l LEFT JOIN `bcc_banks` b ON l.bank_id = b.id SET l.bank_id = NULL WHERE l.bank_id IS NOT NULL AND b.id IS NULL;]])
+end
+
+local function restoreForeignKeys()
+    local statements = {
+        'ALTER TABLE `bcc_accounts` ADD CONSTRAINT `FK_accounts_bank` FOREIGN KEY (`bank_id`) REFERENCES `bcc_banks`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_accounts_access` ADD CONSTRAINT `FK_baa_account` FOREIGN KEY (`account_id`) REFERENCES `bcc_accounts`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_loans` ADD CONSTRAINT `FK_loans_account` FOREIGN KEY (`account_id`) REFERENCES `bcc_accounts`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_loans` ADD CONSTRAINT `FK_loans_bank` FOREIGN KEY (`bank_id`) REFERENCES `bcc_banks`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_loans_payments` ADD CONSTRAINT `FK_lp_loan` FOREIGN KEY (`loan_id`) REFERENCES `bcc_loans`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_transactions` ADD CONSTRAINT `FK_t_account` FOREIGN KEY (`account_id`) REFERENCES `bcc_accounts`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_safety_deposit_boxes` ADD CONSTRAINT `FK_sdb_bank` FOREIGN KEY (`bank_id`) REFERENCES `bcc_banks`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_safety_deposit_boxes_access` ADD CONSTRAINT `FK_sdba_sdb` FOREIGN KEY (`safety_deposit_box_id`) REFERENCES `bcc_safety_deposit_boxes`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_loan_interest_rates` ADD CONSTRAINT `FK_lir_bank` FOREIGN KEY (`bank_id`) REFERENCES `bcc_banks`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        'ALTER TABLE `bcc_bank_interest_rates` ADD CONSTRAINT `FK_bir_bank` FOREIGN KEY (`bank_id`) REFERENCES `bcc_banks`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;'
+    }
+
+    for _, stmt in ipairs(statements) do
+        local ok, err = pcall(function()
+            MySQL.query.await(stmt)
+        end)
+        if not ok then
+            devPrint('[migration] Failed to recreate FK:', stmt, err)
+        end
+    end
+end
+
+function RunLegacyIdMigration()
+    -- Detect if any legacy numeric identifiers remain
+    local legacyBanks = countNumericIds('bcc_banks', 'id')
+    local legacyAccounts = countNumericIds('bcc_accounts', 'id')
+    local legacyLoans = countNumericIds('bcc_loans', 'id')
+    local legacySDBs = countNumericIds('bcc_safety_deposit_boxes', 'id')
+    local legacyTransactions = countNumericIds('bcc_transactions', 'id')
+    local legacyLoanPayments = countNumericIds('bcc_loans_payments', 'id')
+
+    if legacyBanks == 0 and legacyAccounts == 0 and legacyLoans == 0 and legacySDBs == 0 and legacyTransactions == 0 and legacyLoanPayments == 0 then
+        devPrint('[migration] No legacy numeric identifiers detected; skipping migration.')
+        return
+    end
+
+    devPrint(('[migration] Legacy numeric identifiers detected (banks=%d, accounts=%d, loans=%d, sdbs=%d, tx=%d, loan_payments=%d). Starting migration...'):format(legacyBanks, legacyAccounts, legacyLoans, legacySDBs, legacyTransactions, legacyLoanPayments))
+
+    local fkDisabled = false
+    local totalConverted = 0
+
+    local ok, err = pcall(function()
+        MySQL.query.await('SET FOREIGN_KEY_CHECKS = 0;')
+        fkDisabled = true
+
+        -- Drop existing foreign keys that reference the tables we are about to mutate
+        dropForeignKeysReferencing('bcc_banks', 'id')
+        dropForeignKeysReferencing('bcc_accounts', 'id')
+        dropForeignKeysReferencing('bcc_loans', 'id')
+        dropForeignKeysReferencing('bcc_safety_deposit_boxes', 'id')
+
+        -- Ensure columns are typed as VARCHAR(36) prior to updates
+        ensureColumnIsVarchar('bcc_banks', 'id')
+        ensureColumnIsVarchar('bcc_accounts', 'id')
+        ensureColumnIsVarchar('bcc_accounts', 'bank_id')
+        ensureColumnIsVarchar('bcc_accounts_access', 'account_id')
+        ensureColumnIsVarchar('bcc_loans', 'id')
+        ensureOptionalColumnIsVarchar('bcc_loans', 'account_id')
+        ensureOptionalColumnIsVarchar('bcc_loans', 'bank_id')
+        ensureOptionalColumnIsVarchar('bcc_loans', 'disbursed_account_id')
+        ensureColumnIsVarchar('bcc_loans_payments', 'id')
+        ensureColumnIsVarchar('bcc_loans_payments', 'loan_id')
+        ensureColumnIsVarchar('bcc_bank_interest_rates', 'bank_id')
+        ensureColumnIsVarchar('bcc_loan_interest_rates', 'bank_id')
+        ensureColumnIsVarchar('bcc_safety_deposit_boxes', 'id')
+        ensureColumnIsVarchar('bcc_safety_deposit_boxes', 'bank_id')
+        ensureColumnIsVarchar('bcc_safety_deposit_boxes_access', 'safety_deposit_box_id')
+        ensureColumnIsVarchar('bcc_transactions', 'id')
+        ensureOptionalColumnIsVarchar('bcc_transactions', 'account_id')
+        ensureOptionalColumnIsVarchar('bcc_transactions', 'loan_id')
+
+        -- Build mapping tables for legacy identifiers
+        local bankMappingCount = legacyBanks
+        if bankMappingCount > 0 then
+            buildMappingTable('bcc_banks', 'id', 'bcc_migration_tmp_banks')
+            migrateBanks('bcc_migration_tmp_banks')
+            totalConverted = totalConverted + bankMappingCount
+        end
+
+        local accountMappingCount = legacyAccounts
+        if accountMappingCount > 0 then
+            buildMappingTable('bcc_accounts', 'id', 'bcc_migration_tmp_accounts')
+            migrateAccounts('bcc_migration_tmp_accounts')
+            totalConverted = totalConverted + accountMappingCount
+        end
+
+        local sdbMappingCount = legacySDBs
+        if sdbMappingCount > 0 then
+            buildMappingTable('bcc_safety_deposit_boxes', 'id', 'bcc_migration_tmp_sdbs')
+            migrateSafetyDepositBoxes('bcc_migration_tmp_sdbs')
+            totalConverted = totalConverted + sdbMappingCount
+        end
+
+        local loanMappingCount = legacyLoans
+        if loanMappingCount > 0 then
+            buildMappingTable('bcc_loans', 'id', 'bcc_migration_tmp_loans')
+            migrateLoans('bcc_migration_tmp_loans')
+            totalConverted = totalConverted + loanMappingCount
+        end
+
+        local loanPaymentMappingCount = legacyLoanPayments
+        if loanPaymentMappingCount > 0 then
+            buildMappingTable('bcc_loans_payments', 'id', 'bcc_migration_tmp_loan_payments')
+            migrateLoanPayments('bcc_migration_tmp_loan_payments')
+            totalConverted = totalConverted + loanPaymentMappingCount
+        end
+
+        local transactionMappingCount = legacyTransactions
+        if transactionMappingCount > 0 then
+            buildMappingTable('bcc_transactions', 'id', 'bcc_migration_tmp_transactions')
+            migrateTransactions('bcc_migration_tmp_transactions')
+            totalConverted = totalConverted + transactionMappingCount
+        end
+
+        -- Clean up orphaned data created by deleted banks
+        cleanupOrphans()
+
+        -- Drop mapping tables
+        dropMappingTable('bcc_migration_tmp_transactions')
+        dropMappingTable('bcc_migration_tmp_loan_payments')
+        dropMappingTable('bcc_migration_tmp_loans')
+        dropMappingTable('bcc_migration_tmp_sdbs')
+        dropMappingTable('bcc_migration_tmp_accounts')
+        dropMappingTable('bcc_migration_tmp_banks')
+
+        -- Restore foreign keys
+        restoreForeignKeys()
+    end)
+
+    if fkDisabled then
+        MySQL.query.await('SET FOREIGN_KEY_CHECKS = 1;')
+    end
+
+    if not ok then
+        error(err)
+    end
+
+    devPrint(string.format('[migration] Legacy migration complete. %d primary identifiers converted to UUIDs.', totalConverted))
+end
+
+CreateThread(function()
+    Wait(1500)
+    local ok, err = pcall(RunLegacyIdMigration)
+    if not ok and err then
+        print(('^1[bcc-banks] Legacy ID migration failed: %s^0'):format(err))
+    end
+end)

--- a/server/services/safetydepositboxes.lua
+++ b/server/services/safetydepositboxes.lua
@@ -14,7 +14,7 @@ BccUtils.RPC:Register('Feather:Banks:GetSDBs', function(params, cb, src)
         return
     end
     local characterId = char.charIdentifier
-    local bankId = tonumber(params and params.bank)
+    local bankId = NormalizeId(params and params.bank)
 
     if not characterId or not bankId then
         devPrint("GetSDBs: invalid inputs", "characterId=", characterId, "bankId=", bankId)
@@ -46,7 +46,7 @@ BccUtils.RPC:Register('Feather:Banks:CreateSDB', function(params, cb, src)
     -- inputs
     local characterId = char.charIdentifier          -- adjust if your framework uses a different name
     local name        = params and params.name
-    local bank        = tonumber(params and params.bank)
+    local bank        = NormalizeId(params and params.bank)
     local sizeKey     = params and params.size
     local payWith     = (params and params.payWith) or "cash"  -- "cash" | "gold"
 
@@ -229,7 +229,7 @@ BccUtils.RPC:Register('Feather:Banks:OpenSDB', function(params, cb, src)
         return
     end
     local characterId = char.charIdentifier
-    local sdbId = tonumber(params and params.sdb_id)
+    local sdbId = NormalizeId(params and params.sdb_id)
 
     if not characterId or not sdbId then
         devPrint("OpenSDB: invalid inputs", "characterId=", characterId, "sdbId=", sdbId)
@@ -283,7 +283,7 @@ BccUtils.RPC:Register('Feather:Banks:OpenSDB', function(params, cb, src)
 end)
 
 BccUtils.RPC:Register('Feather:Banks:GetSDBAccessList', function(params, cb, src)
-    local sdbId = tonumber(params and params.sdb_id)
+    local sdbId = NormalizeId(params and params.sdb_id)
     if not sdbId then
         devPrint("GetSDBAccessList: invalid sdbId", params and params.sdb_id)
         NotifyClient(src, _U('error_invalid_sdb_id'), 'error', 4000)
@@ -337,7 +337,7 @@ BccUtils.RPC:Register('Feather:Banks:AddSDBAccess', function(params, cb, src)
         end
         requesterId = ch.charIdentifier
     end
-    local sdbId         = tonumber(params and params.sdb_id)
+    local sdbId         = NormalizeId(params and params.sdb_id)
     -- Expect a VORP character identifier (charidentifier). Keep compatibility with older param name 'user_src'
     local otherCharId   = tonumber(params and params.character) or tonumber(params and params.user_src)
     if not otherCharId then
@@ -419,7 +419,7 @@ BccUtils.RPC:Register('Feather:Banks:RemoveSDBAccess', function(params, cb, src)
     end
     local requesterId = user.getUsedCharacter.charIdentifier
 
-    local sdbId = tonumber(params and params.sdb_id)
+    local sdbId = NormalizeId(params and params.sdb_id)
     local targetCharId = tonumber(params and params.character)
 
     devPrint("Parsed inputs → sdbId:", sdbId, "target:", targetCharId, "requesterId:", requesterId)

--- a/server/services/transactions.lua
+++ b/server/services/transactions.lua
@@ -1,7 +1,7 @@
 BccUtils.RPC:Register('Feather:Banks:GetTransactions', function(params, cb, src)
     devPrint("RPC called by src:", src)
 
-    local account = tonumber(params and params.account)
+    local account = NormalizeId(params and params.account)
     devPrint("Received account ID:", account)
 
     if not account then

--- a/version
+++ b/version
@@ -1,2 +1,3 @@
-<1.1.1>
+<1.2.0>
+Please make a backup of database before updating this script to this version!
 See GitHub for details!


### PR DESCRIPTION
- Replace numeric IDs with BccUtils.UUID() across accounts, loans, transactions, banks, and SDBs.
- Add startup migration to convert existing tables/rows from numeric IDs to UUID v4, updating FK references and column types to VARCHAR(36).
- Also introduces collision-checked 8‑digit account_number generation.